### PR TITLE
Add README and LICENSE files to zip packages

### DIFF
--- a/.github/workflows/build-executables.yml
+++ b/.github/workflows/build-executables.yml
@@ -80,14 +80,18 @@ jobs:
     - name: Zip executable (Windows)
       if: matrix.os == 'windows-latest'
       run: |
-        Compress-Archive -Path dist/proxy.exe -DestinationPath dist/proxy.zip
+        Copy-Item README.md -Destination dist/
+        Copy-Item LICENSE -Destination dist/
+        Compress-Archive -Path dist/proxy.exe, dist/README.md, dist/LICENSE -DestinationPath dist/proxy.zip
       shell: powershell
 
     - name: Zip executable (macOS)
       if: matrix.os == 'macos-latest'
       run: |
+        cp README.md dist/
+        cp LICENSE dist/
         cd dist
-        zip proxy-macos.zip proxy
+        zip proxy-macos.zip proxy README.md LICENSE
       
     - name: Upload artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
This PR modifies the GitHub Actions workflow to include README.md and LICENSE files in the zip packages for both Windows and macOS builds.

### Changes:
- For Windows: Added steps to copy README.md and LICENSE to the dist directory and include them in the zip archive
- For macOS: Added steps to copy README.md and LICENSE to the dist directory and include them in the zip archive

These changes ensure that users who download the packages will have access to important documentation and license information.