### PR TITLE
Add --flatten-content option to convert single-text content arrays to strings

### DIFF
--- a/FLATTEN_CONTENT_FEATURE.md
+++ b/FLATTEN_CONTENT_FEATURE.md
@@ -1,0 +1,115 @@
+# Content Flattening Feature
+
+## Overview
+Added a new `--flatten-content` option that converts message content from array format to string format when the array contains only a single text element.
+
+## Implementation Details
+
+### New Function: `flatten_content_in_body(body: dict) -> dict`
+- Located in `proxy.py` after the `get_logs_directory()` function
+- Performs deep copy to avoid modifying original request
+- Only flattens content arrays with exactly one element of type "text"
+- Preserves all other content structures unchanged
+
+### Command Line Options
+- Added `--flatten-content` flag to both `server` and `replay` modes
+- Server mode: Applies flattening to all incoming requests before forwarding
+- Replay mode: Applies flattening to replayed requests when flag is used
+
+### Global State Management
+- Added `FLATTEN_CONTENT` global variable to track server-wide setting
+- Updated in `run_server()` function based on command line argument
+
+### Modified Functions
+1. **`proxy()` endpoint**: Now applies flattening before forwarding requests
+2. **`replay_request_from_file()`**: Added optional `flatten_content` parameter
+3. **`run_server()`**: Sets global flag and displays status
+4. **`run_replay()`**: Passes flag to replay function
+5. **`parse_arguments()`**: Added new argument to both parsers
+
+## Usage Examples
+
+### Server Mode
+```bash
+# Enable content flattening
+python proxy.py server --flatten-content
+
+# With other options
+python proxy.py server --port 9000 --flatten-content --target-url https://api.openai.com/v1/chat/completions
+```
+
+### Replay Mode
+```bash
+# Replay with content flattening
+python proxy.py replay log_file.json --flatten-content
+
+# Combined with other options
+python proxy.py replay log_file.json --flatten-content --target-url https://test-api.com --output json
+```
+
+## Transformation Example
+
+**Input:**
+```json
+{
+  "messages": [
+    {
+      "role": "system",
+      "content": [
+        {
+          "type": "text",
+          "text": "you are an helpful assistant"
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "text",
+          "text": "write a poem"
+        }
+      ]
+    }
+  ],
+  "model": "mistral",
+  "stop": ["<end_code>"]
+}
+```
+
+**Output:**
+```json
+{
+  "messages": [
+    {
+      "role": "system",
+      "content": "you are an helpful assistant"
+    },
+    {
+      "role": "user",
+      "content": "write a poem"
+    }
+  ],
+  "model": "mistral",
+  "stop": ["<end_code>"]
+}
+```
+
+## Edge Cases Handled
+- Multi-element content arrays: Not flattened
+- Non-text content types: Not flattened
+- Already flattened content: Unchanged
+- Missing text field: Not flattened
+- Empty content arrays: Not flattened
+- Invalid/missing messages: Handled gracefully
+
+## Testing
+- Comprehensive test coverage for all edge cases
+- Integration testing for end-to-end functionality
+- Command line interface testing
+- Server startup verification
+
+## Documentation Updates
+- Updated README.md with feature description and examples
+- Added help text to command line arguments
+- Updated usage examples in argument parser

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A simple FastAPI proxy server for calling LLMs with HTTP request logging and rep
 - Automatic request logging
 - Request replay from logs
 - Support for header and target URL modification
+- Content flattening for single-text message arrays
 
 ## Installation
 
@@ -61,11 +62,64 @@ The executable will be created in the `dist/` folder.
 ### Start the server
 
 ```bash
-# With Python
-uv run uvicorn proxy:app --host 0.0.0.0 --port 8000
+# Basic usage
+python proxy.py server
+
+# With custom options
+python proxy.py server --port 9000 --host 127.0.0.1
+
+# Enable content flattening (converts single-text content arrays to strings)
+python proxy.py server --flatten-content
 
 # With the executable
-./dist/proxy --host 0.0.0.0 --port 8000
+./dist/proxy server --host 0.0.0.0 --port 8000
+```
+
+### Content Flattening
+
+The `--flatten-content` option automatically converts message content from array format to string format when the array contains only a single text element. This is useful for APIs that expect simplified content structures.
+
+**Example transformation:**
+```json
+// Before flattening
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "text",
+          "text": "Hello, world!"
+        }
+      ]
+    }
+  ]
+}
+
+// After flattening
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": "Hello, world!"
+    }
+  ]
+}
+```
+
+**Note:** Only single-element arrays with `type: "text"` are flattened. Multi-element arrays and other content types remain unchanged.
+
+### Replay Requests
+
+```bash
+# Replay a saved request
+python proxy.py replay <log_file_path>
+
+# Replay with content flattening
+python proxy.py replay <log_file_path> --flatten-content
+
+# Replay to a different endpoint
+python proxy.py replay <log_file_path> --target-url https://api.openai.com/v1/chat/completions
 ```
 
 


### PR DESCRIPTION
## Overview
This PR adds a new `--flatten-content` option that automatically converts message content from array format to string format when the array contains only a single text element. This is useful for APIs that expect simplified content structures.

## Changes Made

### Core Functionality
- **New function**: `flatten_content_in_body()` - Handles content transformation with deep copy to preserve original requests
- **Server mode**: Added `--flatten-content` flag that applies flattening to all incoming requests before forwarding
- **Replay mode**: Added `--flatten-content` flag for replaying requests with content flattening
- **Global state management**: Added `FLATTEN_CONTENT` variable to track server-wide setting

### Command Line Interface
- Added `--flatten-content` argument to both `server` and `replay` parsers
- Updated help text with usage examples and descriptions
- Enhanced server startup output to show flattening status

### Documentation
- Updated README.md with feature description and transformation examples
- Added comprehensive usage examples for both server and replay modes
- Created detailed feature documentation in `FLATTEN_CONTENT_FEATURE.md`

## Transformation Example

**Before flattening:**
```json
{
  "messages": [
    {
      "role": "user",
      "content": [
        {
          "type": "text",
          "text": "Hello, world!"
        }
      ]
    }
  ]
}
```

**After flattening:**
```json
{
  "messages": [
    {
      "role": "user",
      "content": "Hello, world!"
    }
  ]
}
```

## Edge Cases Handled
- ✅ Multi-element content arrays: Not flattened (preserved as-is)
- ✅ Non-text content types (e.g., image_url): Not flattened
- ✅ Already flattened content: Unchanged
- ✅ Missing text field: Not flattened
- ✅ Empty content arrays: Not flattened
- ✅ Invalid/missing messages: Handled gracefully

## Usage Examples

### Server Mode
```bash
# Enable content flattening
python proxy.py server --flatten-content

# With other options
python proxy.py server --port 9000 --flatten-content
```

### Replay Mode
```bash
# Replay with content flattening
python proxy.py replay log_file.json --flatten-content
```

## Testing
- Comprehensive test coverage for all transformation scenarios
- Edge case validation for various content structures
- Command line interface verification
- Integration testing for end-to-end functionality

## Backward Compatibility
- ✅ Fully backward compatible - feature is opt-in via flag
- ✅ Original request structure preserved in logs
- ✅ No changes to existing API behavior when flag is not used

This enhancement addresses the need for content format normalization while maintaining full compatibility with existing workflows.

@a3lentyr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d1b7849100574c988185a08307fed8d6)