### PR TITLE
Make request logging optional and improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ A simple FastAPI proxy server for calling LLMs with HTTP request logging and rep
 ## Features
 
 - HTTP proxy with FastAPI
-- Automatic request logging
+- Optional request logging (disabled by default)
 - Request replay from logs
 - Support for header and target URL modification
 - Content flattening for single-text message arrays
+- Tool role replacement for compatibility with different LLM providers
 
 ## Installation
 
@@ -26,8 +27,11 @@ cd munchFORsen
 # Install dependencies with UV
 uv sync
 
-# Start the server
+# Start the server (development mode with auto-reload)
 uv run uvicorn proxy:app --reload
+
+# Or run the server directly with command-line options
+uv run python proxy.py server --port 8000
 ```
 
 ## Local Build
@@ -71,6 +75,12 @@ python proxy.py server --port 9000 --host 127.0.0.1
 # Enable content flattening (converts single-text content arrays to strings)
 python proxy.py server --flatten-content
 
+# Replace tool-call and tool-response roles with user role
+python proxy.py server --no-tool-roles
+
+# Enable request logging (disabled by default)
+python proxy.py server --log
+
 # With the executable
 ./dist/proxy server --host 0.0.0.0 --port 8000
 ```
@@ -109,6 +119,62 @@ The `--flatten-content` option automatically converts message content from array
 
 **Note:** Only single-element arrays with `type: "text"` are flattened. Multi-element arrays and other content types remain unchanged.
 
+### Request Logging
+
+By default, request logging is disabled to improve performance and reduce disk usage. Use the `--log` flag to enable logging of all requests to files. These logs can later be used with the replay functionality.
+
+```bash
+# Enable request logging
+python proxy.py server --log
+```
+
+Logs are saved in:
+- Windows: `%USERPROFILE%\AppData\Local\Proxy\logs`
+- macOS/Linux: `~/.local/share/proxy/logs`
+
+### Tool Role Replacement
+
+The `--no-tool-roles` option replaces "tool-call" and "tool-response" roles with "user" role in messages. This is useful for compatibility with LLM providers that don't support these specialized roles.
+
+**Example transformation:**
+```json
+// Before replacement
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": "What's the weather?"
+    },
+    {
+      "role": "tool-call",
+      "content": "Calling weather API..."
+    },
+    {
+      "role": "tool-response",
+      "content": "It's sunny, 75°F"
+    }
+  ]
+}
+
+// After replacement
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": "What's the weather?"
+    },
+    {
+      "role": "user",
+      "content": "Calling weather API..."
+    },
+    {
+      "role": "user",
+      "content": "It's sunny, 75°F"
+    }
+  ]
+}
+```
+
 ### Replay Requests
 
 ```bash
@@ -122,6 +188,42 @@ python proxy.py replay <log_file_path> --flatten-content
 python proxy.py replay <log_file_path> --target-url https://api.openai.com/v1/chat/completions
 ```
 
+## Running in Linux or Docker Environments
+
+### Linux Environment
+
+You can run the server directly using `uv run` without installing the package:
+
+```bash
+# Clone the repository
+git clone https://github.com/FOR-sight-ai/munchFORsen.git
+cd munchFORsen
+
+# Install dependencies with UV
+uv sync
+
+# Run the server with options
+uv run python proxy.py server --host 0.0.0.0 --port 8000 --log
+```
+
+### Docker Environment
+
+You can run the server in a Docker container:
+
+```bash
+# Clone the repository
+git clone https://github.com/FOR-sight-ai/munchFORsen.git
+cd munchFORsen
+
+# Build the Docker image
+docker build -t munchforsen .
+
+# Run the container
+docker run -p 8000:8000 munchforsen
+
+# Or with custom options
+docker run -p 9000:9000 munchforsen python proxy.py server --host 0.0.0.0 --port 9000 --log --flatten-content
+```
 
 ## Acknowledgement
 This project received funding from the French ”IA Cluster” program within the Artificial and Natural Intelligence Toulouse Institute (ANITI) and from the "France 2030" program within IRT Saint Exupery. The authors gratefully acknowledge the support of the FOR projects.


### PR DESCRIPTION
## Changes

This PR implements the following changes:

1. **Make request logging optional by default**
   - Added a new `--log` flag to enable logging
   - Logging is now disabled by default to improve performance and reduce disk usage
   - Updated the server startup message to show logging status

2. **Documentation updates**
   - Added documentation for the `--no-tool-roles` flag
   - Added documentation for the new `--log` flag
   - Added a new section explaining how to run the server in Linux and Docker environments
   - Added example JSON transformations for tool role replacement
   - Updated feature list to reflect the optional logging

3. **Running instructions**
   - Added instructions for running with `uv run` directly
   - Added Docker container examples

These changes make the proxy server more efficient by default while still providing the option to enable logging when needed for debugging or replay purposes.

@a3lentyr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6a80ba67b91643d98c94d982bb4e4228)