### PR TITLE
Add CORS support to proxy server

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ python proxy.py server --ssl-no-verify
 # Use custom SSL certificate file
 python proxy.py server --ssl-cert-file /path/to/Root_CA_V3.pem
 
+# Disable CORS (allows all origins, handles preflight requests)
+python proxy.py server --cors disable
+
+# Forward CORS preflight requests to the target address
+python proxy.py server --cors forward
+
 # With the executable
 ./dist/proxy server --host 0.0.0.0 --port 8000
 ```
@@ -307,6 +313,23 @@ python proxy.py replay log_file.json --proxy-url http://proxy.company.com:8080 -
 - Proxy settings are applied globally to all HTTP clients
 
 **Security Note:** Proxy credentials are passed as command-line arguments. In production environments, consider using environment variables or configuration files to avoid exposing credentials in process lists.
+
+### CORS Support
+
+The proxy provides built-in support for Cross-Origin Resource Sharing (CORS), which is essential when calling the proxy from a web browser.
+
+**Options:**
+- `--cors disable`: The proxy handles preflight (`OPTIONS`) requests automatically and adds headers to allow all origins, methods, and headers. This is the easiest way to solve CORS issues during development.
+- `--cors forward`: The proxy forwards all CORS-related requests (including `OPTIONS`) to the target address and forwards the CORS response headers back to the client. This allows the target server to control the CORS policy.
+
+**Usage:**
+```bash
+# Allow all origins (standard dev mode)
+python proxy.py server --cors disable
+
+# Forward CORS to target
+python proxy.py server --cors forward
+```
 
 ### SSL Certificate Management
 


### PR DESCRIPTION
Implemented proper CORS support in the proxy server. Users can now choose between disabling CORS (allowing all origins and automatically responding to preflight requests) or forwarding CORS requests to the target address. The implementation handles both regular and streaming responses, ensuring that CORS-related headers (including Vary: Origin) are correctly relayed. The proxy was also updated to support multiple HTTP methods (GET, POST, PUT, DELETE, OPTIONS, HEAD, PATCH) to accommodate various API styles.

---
*PR created automatically by Jules for task [3170482388251256982](https://jules.google.com/task/3170482388251256982) started by @a3lentyr*